### PR TITLE
Remove the min value on linter

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install -r requirements-dev.txt
-          make lint |& grep 'violations and reported' | [ $(awk '{print $NF}') -le 32 ] && true
+          make lint
       -
         name: Build and Run Kopanocore
         run: |


### PR DESCRIPTION
As all lint issues have been fixed or ignored, we don't need any minimum value for the linter anymore. So, any PR should have zero lint error.