### PR TITLE
Suggested solution to 'yielder' problem in resources.py

### DIFF
--- a/grapi/backend/kopano/resource.py
+++ b/grapi/backend/kopano/resource.py
@@ -339,6 +339,6 @@ class Resource(BaseResource):
         if '$search' in args:
             query = args['$search'][0]
             
-            return self.generator(req, yielder, 0, args=args, query=query, store=folder.store)
+            return self.generator(req, folder.items, 0, args=args, query=query, store=folder.store)
         else:
             return self.generator(req, folder.items, folder.count, args=args)


### PR DESCRIPTION
The yielder() took away the advantages of a generator: generate the data in place. By the yielder, the program had to go through the whole generator function before knowing the pagination. This became problematic for huge data sets (i.e. >15000). With the proposed design, the actual query is delivered alongside with the store to the generator function and the generator is fed with the restriction. The restriction is necessary, as only folder.items has a query parameter, whereas folder.folders and folder.items both have a restriction parameter.