### PR TITLE
Enable inital synching

### DIFF
--- a/grapi/backend/kopano/item.py
+++ b/grapi/backend/kopano/item.py
@@ -61,7 +61,7 @@ class ItemResource(Resource):
     @experimental
     def delta(self, req, resp, folder):
         args = self.parse_qs(req)
-        token = args['$deltatoken'][0] if '$deltatoken' in args else None
+        token = args['$deltatoken'][0] if '$deltatoken' in args else folder.state
         filter_ = args['$filter'][0] if '$filter' in args else None
         begin = None
         if filter_ and filter_.startswith('receivedDateTime ge '):


### PR DESCRIPTION
I had difficulties to get syncing running with graph. Usually, with python-kopano, one would fetch folder.state and sync, thereby fetching another state. These states could be compared and respective actions could be performed.

In graph, there is no folder.state. The mailFolder Ressource simply does not know it. Therefore, the folder.state needs to be retrieved somewhere from. In the initial code, I hade to do a sync with a certain time (i.e. datetime.datetime.now()) to retrieve the latest state. However, when using this state as a deltatoken to ask for an update, something does not work. Apparently, the state is wrong. Kopano seems to hang. Hence, I modified the code to allow for returning an initial deltatoken for the first messages/delta (i.e. without any token). Thus, in analogy to the python-kopano way, one would do a messages/delta first retrieving a token and then provide that token to the next delta request.

I don't know whether this is the intended way of MS Graph, i.e. whether a simple messages/delta returns the current state of the folder or the oldest state of the folder. The modified code returns the current state.